### PR TITLE
Corrected theme prop value in buttonstyle 

### DIFF
--- a/fusion/Button.js
+++ b/fusion/Button.js
@@ -1,44 +1,48 @@
-import { css } from 'emotion';
-import PropTypes from 'prop-types';
-import React from 'react';
-import { withTheme } from 'theming';
+import { css } from "emotion";
+import PropTypes from "prop-types";
+import React from "react";
+import { withTheme } from "theming";
 
-const buttonStyle = css`
-    background-color:${props => props.theme.buttonColor}; 
-    color:${props => props.theme.buttonTextColor};
-    border-radius:5px;
-      padding:0.5rem 1rem;
-    font-size: 1rem;
-    border: none;
-    cursor: pointer;
-
+const buttonStyle = theme => css`
+	background-color: ${theme.buttonColor};
+	color: ${theme.buttonTextColor};
+	border-radius: 5px;
+	padding: 0.5rem 1rem;
+	font-size: 1rem;
+	border: none;
+	cursor: pointer;
 `;
 
-const Button = ({ children, onClick, disabled }) => (<button
-  type="button"
-  onClick={onClick}
-  className={buttonStyle}
-  disabled={disabled}
->
-  {children}
-</button>);
+const Button = props => {
+	const { children, onClick, disabled, theme } = props;
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={buttonStyle(theme)}
+			disabled={disabled}
+		>
+			{children}
+		</button>
+	);
+};
 
 Button.propTypes = {
-  /**
-   * onClick Function
-   */
-  onClick: PropTypes.func,
-  /**
-   * Children
-   */
-  children: PropTypes.string,
-  /**
-   * disabled
-   */
-  disabled: PropTypes.bool,
+	/**
+	 * onClick Function
+	 */
+	onClick: PropTypes.func,
+	/**
+	 * Children
+	 */
+	children: PropTypes.string,
+	/**
+	 * disabled
+	 */
+	disabled: PropTypes.bool
 };
 
 Button.defaultProps = {
-  disabled: false,
+	disabled: false
 };
 export default withTheme(Button);


### PR DESCRIPTION
const buttonStyle = css`
-    background-color:${props => props.theme.buttonColor}; 
-    color:${props => props.theme.buttonTextColor};
In the above lines how the context of props is  retained (in the browser if u check, this two property are taken as invalid)
**My solution**
buttonStyle = theme => css`
+	background-color: ${theme.buttonColor};
+	color: ${theme.buttonTextColor};

and called buttonStyle function from button context passing correct props.